### PR TITLE
Fix: malformed p tags in error message and helper text

### DIFF
--- a/component-library/components/generic/form/error-message/error-message.eleventy.liquid
+++ b/component-library/components/generic/form/error-message/error-message.eleventy.liquid
@@ -2,5 +2,5 @@
 
 <div class="{{ c }} error">
     {% bookshop "generic/hero-library-icon" hero_library_icon_name:"x-circle" icon_type:"outline" icon_size:'extra-small' rounded_border:false color:'var(--error-color, #BF2323)' %}
-    <p class="{{ c }}__error__text error__text" id="{{ id }}--error">{{ error_message }}<p>
+    <p class="{{ c }}__error__text error__text" id="{{ id }}--error">{{ error_message }}</p>
 </div>

--- a/component-library/components/generic/form/helper-text/helper-text.eleventy.liquid
+++ b/component-library/components/generic/form/helper-text/helper-text.eleventy.liquid
@@ -2,5 +2,5 @@
 
 <div class="{{ c }}">
     {% bookshop "generic/hero-library-icon" hero_library_icon_name:"information-circle" icon_type:"outline" icon_size:'extra-small' rounded_border:false color:'var(--primary-foreground-color, #F9F9FB)' %}
-    <p class="{{ c }}__helper__text" id="{{ id }}--helper" role="tooltip">{{ helper_text }}<p>
+    <p class="{{ c }}__helper__text" id="{{ id }}--helper" role="tooltip">{{ helper_text }}</p>
 </div>


### PR DESCRIPTION
# Context

- Small PR to fix malformed p tags in generic/form/error-message and generic/form/helper-text components
- Just added missing end tag slashes

# Review

- Check code
- Check site: [https://fresh-pencil.cloudvent.net/booking/](https://fresh-pencil.cloudvent.net/booking/)

# After review

- Delete test site