### PR TITLE
Fix/navigation color group

### DIFF
--- a/src/_data/footer.yml
+++ b/src/_data/footer.yml
@@ -13,4 +13,4 @@ navigation_items:
 footer_content: >-
   ©Enter your copyright and [terms and conditions](/terms-and-conditions/ "Terms
   and Conditions").
-footer_color_group: primary
+footer_color_group: secondary0

--- a/src/_data/nav.yml
+++ b/src/_data/nav.yml
@@ -10,4 +10,4 @@ navigation_items:
   - label: Contact Us
     link_url: /contact
     open_in_new_tab: false
-nav_color_group: primary
+nav_color_group: secondary0

--- a/utils/fetch-theme-variables.js
+++ b/utils/fetch-theme-variables.js
@@ -77,6 +77,9 @@ css_string_component += `--main-text-color : ${primary_color.foreground_color};\
 css_string_component += `--interaction-color : ${primary_color.interaction_color};\n`
 css_string_component += `}\n`
 
+css_string_nav = addColorDefinitions(css_string_nav, 'primary')      
+css_string_footer = addColorDefinitions(css_string_footer, 'primary') 
+
 config['_inputs']['color_group']['options']['values'].push({id: 'primary', name: primary_color.name})
 
 /* 


### PR DESCRIPTION
# Context

- PR to fix the navigation (and footer) not using the primary color group
- Default colors had been added, and new custom color groups had been added, but hardcoding the nav and footer primary color groups in CSS was overlooked - not noticed until now because the nav and footer ship with the secondary color group in use
- Updated the fetch-theme-variables.js script to add the primary classes to the CSS file

# Review

- Check code
- Check site: [https://app.cloudcannon.com/42158/editor#sites/120327/dashboard/summary:/edit?editor=visual&url=%2F&collection=pages](https://app.cloudcannon.com/42158/editor#sites/120327/dashboard/summary:/edit?editor=visual&url=%2F&collection=pages)

# After review

- Delete test site