### PR TITLE
Venture User Defined Color Groups Fix for Unified Configuration

### DIFF
--- a/cloudcannon.config.yml
+++ b/cloudcannon.config.yml
@@ -45,8 +45,8 @@ file_config:
 data_config:
   fonts:
     path: _data/fonts.yml
-  color_groups:
-    path: _data/color_groups.yml
+  theme:
+    path: _data/theme.yml
   site:
     path: _data/site.yml
 _inputs:

--- a/cloudcannon.config.yml
+++ b/cloudcannon.config.yml
@@ -213,7 +213,7 @@ _inputs:
           - key: name
         icon:
           - key: icon
-      values: data.theme..[?(@.primaryColor)]
+      values: data.theme..[?(@.background_color)]
   card_color_group:
     comment: >-
       Choose the color group for the cards in this grid. It is recommended to
@@ -225,7 +225,7 @@ _inputs:
           - key: name
         icon:
           - key: icon
-      values: data.theme..[?(@.primaryColor)]
+      values: data.theme..[?(@.background_color)]
   group_name:
     hidden: true
     comment: >-
@@ -240,7 +240,7 @@ _inputs:
           - key: name
         icon:
           - key: icon
-      values: data.theme..[?(@.primaryColor)]
+      values: data.theme..[?(@.background_color)]
   footer_color_group:
     comment: Choose the color group for the footer.
     type: select
@@ -250,7 +250,7 @@ _inputs:
           - key: name
         icon:
           - key: icon
-      values: data.theme..[?(@.primaryColor)]
+      values: data.theme..[?(@.background_color)]
   primary_color_group:
     comment: The default color group for styling site components.
   primary_color_group.name:

--- a/cloudcannon.config.yml
+++ b/cloudcannon.config.yml
@@ -213,7 +213,7 @@ _inputs:
           - key: name
         icon:
           - key: icon
-      values: data.color_groups
+      values: data.theme..[?(@.primaryColor)]
   card_color_group:
     comment: >-
       Choose the color group for the cards in this grid. It is recommended to
@@ -225,7 +225,7 @@ _inputs:
           - key: name
         icon:
           - key: icon
-      values: data.color_groups
+      values: data.theme..[?(@.primaryColor)]
   group_name:
     hidden: true
     comment: >-
@@ -240,7 +240,7 @@ _inputs:
           - key: name
         icon:
           - key: icon
-      values: data.color_groups
+      values: data.theme..[?(@.primaryColor)]
   footer_color_group:
     comment: Choose the color group for the footer.
     type: select
@@ -250,7 +250,7 @@ _inputs:
           - key: name
         icon:
           - key: icon
-      values: data.color_groups
+      values: data.theme..[?(@.primaryColor)]
   primary_color_group:
     comment: The default color group for styling site components.
   primary_color_group.name:

--- a/src/_data/theme.yml
+++ b/src/_data/theme.yml
@@ -1,5 +1,5 @@
 primary_color_group:
-  id: 73c15767-04a0-4e6c-ab55-9ba6dd3860cd
+  id: primary
   name: Primary
   background_color: '#3b3b3d'
   foreground_color: '#f9f9fb'

--- a/src/_data/theme.yml
+++ b/src/_data/theme.yml
@@ -5,7 +5,7 @@ primary_color_group:
   foreground_color: '#f9f9fb'
   interaction_color: '#2566f2'
 custom_color_groups:
-  - id: f6ad0210-e856-4e5a-9a46-15aa19de7411
+  - id: secondary0
     name: Secondary
     background_color: '#1b1b1d'
     foreground_color: '#d9d9dc'

--- a/src/_data/theme.yml
+++ b/src/_data/theme.yml
@@ -1,13 +1,20 @@
 primary_color_group:
+  id: 73c15767-04a0-4e6c-ab55-9ba6dd3860cd
   name: Primary
   background_color: '#3b3b3d'
   foreground_color: '#f9f9fb'
   interaction_color: '#2566f2'
 custom_color_groups:
-  - name: Secondary
+  - id: f6ad0210-e856-4e5a-9a46-15aa19de7411
+    name: Secondary
     background_color: '#1b1b1d'
     foreground_color: '#d9d9dc'
     interaction_color: '#2566f2'
 heading_font: Lato
 content_font: Lato
 logo_font: Major Mono Display
+_inputs:
+  id:
+    hidden: true
+    instance_value: UUID
+

--- a/utils/fetch-theme-variables.js
+++ b/utils/fetch-theme-variables.js
@@ -82,7 +82,7 @@ customColorGroups.forEach((group, i) => {
         - replace illegal characters
         - append index to end for auto-increment unique ids
     */
-	const id = `${group.name.toLowerCase().replace(/[\s|&;$%@'"<>()+,]/g, "_")}${i}`;
+	const id = `${group.id}`;
 	const name = group.name;
 	const background = group.background_color;
 	const foreground = group.foreground_color;

--- a/utils/fetch-theme-variables.js
+++ b/utils/fetch-theme-variables.js
@@ -3,7 +3,6 @@ const yaml = require("js-yaml");
 
 const generatedWith = "Generated with fetch-theme-variables.js";
 const themeDataPath = "src/_data/theme.yml";
-const colorGroupsDataPath = "src/_data/color_groups.yml";
 const colorGroupsStylePath = "src/assets/styles/color_groups.scss";
 const variableStylePath = "src/assets/styles/variables.scss";
 
@@ -71,12 +70,6 @@ cssStringComponent += `}\n`;
 cssStringNav = addColorDefinitions(cssStringNav, "primary");
 cssStringFooter = addColorDefinitions(cssStringFooter, "primary");
 
-const colorGroupsData = [
-	{
-		id: "primary",
-		name: primaryColorGroup.name,
-	},
-];
 
 /*
     iterate through all the user defined color_groups and:
@@ -95,7 +88,6 @@ customColorGroups.forEach((group, i) => {
 	const foreground = group.foreground_color;
 	const interaction = group.interaction_color;
 
-	colorGroupsData.push({ id, name });
 
 	cssStringRoot += `\t--${id}__background : ${background};\n`;
 	cssStringRoot += `\t--${id}__foreground : ${foreground};\n`;
@@ -111,9 +103,6 @@ cssStringComponent += `}\n\n`;
 cssStringNav += `}\n\n`;
 cssStringFooter += `}\n\n`;
 
-// write the new values to the color groups data file
-console.log(`[fetch-theme-variables] Writing ${colorGroupsDataPath}`);
-fs.writeFileSync(colorGroupsDataPath, `# ${generatedWith}\n\n` + yaml.dump(colorGroupsData));
 
 // write the css strings into a single file
 console.log(`[fetch-theme-variables] Writing ${colorGroupsStylePath}`);


### PR DESCRIPTION
The existing Venture color theming doesn't seem to work after it was migrated to the universal config.

While everything works if developing locally, its not completely functional within CloudCannon. If a user defines a new custom color group, the build process does not commit the changes made at build time to the color_groups.yml. As a consequence the user cannot use newly defined custom colors groups besides the one that comes preloaded, even after a successful build. The proposed changes is how I've managed to fix the issue. Querying by `background_color` instead of `id` was chosen because it is feasible that upon extending the theme file other objects may be created with unique `id`. If thinking that far ahead for what a user might do is out of scope, then the query could be modified to use `id` instead.

Another benefit, using UUID instead of an ID derived from the name is a better approach as if a user change the name of an existing color group, that link is broken anywhere where the cologroup was previously referenced.